### PR TITLE
Prefix http kernel middleware entry with slash in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You don't need to add this package to your service providers.
 Add the middleware in `app/Http/Kernel.php`, adding a new line in the `middleware` array:
 
 ```php
-Monicahq\Cloudflare\Http\Middleware\TrustProxies::class
+\Monicahq\Cloudflare\Http\Middleware\TrustProxies::class
 ```
 
 # Support


### PR DESCRIPTION
I think it's needed?