### PR TITLE
Use fideloper/proxy package

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,32 +23,43 @@ Add the middleware in `app/Http/Kernel.php`, adding a new line in the `middlewar
 \Monicahq\Cloudflare\Http\Middleware\TrustProxies::class
 ```
 
-# Support
+## Existing Laravel application
 
-This package supports Laravel 5.6 or newer.
+This middleware uses [fideloper/proxy][4] as a backend, so you can removes the other `TrustProxies` line from the `middleware` array.
+
+Another option is to extends the [App\Http\Middleware\TrustProxies.php][3] file to `Monicahq\Cloudflare\Http\Middleware\TrustProxies`:
+
+```php
+namespace App\Http\Middleware;
+
+use Illuminate\Http\Request;
+use Monicahq\Cloudflare\Http\Middleware\TrustProxies as Middleware;
+
+class TrustProxies extends Middleware
+{
+    ...
+```
 
 # Refreshing the Cache
 
-This package basically retrieves Cloudflare's IP blocks, and stores in cache.
+This package basically retrieves Cloudflare's IP blocks, and stores them in cache.
+When request comes, the middleware will get Cloudflare's IP blocks from cache, and load them to trusted proxies.
 
-When request comes, loads Cloudflare's IP blocks to trusted proxies.
+Thus, you'll need to refresh the cloudflare cache every day
 
-That's why, you'll need to every day refresh the cache.
-
-You can use the following command for this.
+You can use the following command for this:
 
 ```sh
 php artisan cloudflare:reload
 ```
 
-## Suggestion: add the command in the schedule.
+## Suggestion: add the command in the schedule
 
 Add a new line in `app/Console/Kernel.php`, in the `schedule` function:
 
 ```php
 $schedule->command('cloudflare:reload')->daily();
 ```
-
 
 # View current Cloudflare's IP blocks
 
@@ -57,6 +68,21 @@ You can use the following command to see the cached IP blocks.
 ```sh
 php artisan cloudflare:view
 ```
+
+# Option: publish the package config file
+
+If you want, you can publish the package config file to `config/laravelcloudflare.php`:
+
+```sh
+php artisan vendor:publish --provider="Monicahq\Cloudflare\TrustedProxyServiceProvider"
+```
+
+This file contains some configurations, but you may not need to change them normally.
+
+
+# Support
+
+This package supports Laravel 5.6 or newer.
 
 # License
 
@@ -68,3 +94,5 @@ This package was inspired by [lukasz-adamski/laravel-cloudflare][1] and forked f
 
 [1]: https://github.com/lukasz-adamski/laravel-cloudflare
 [2]: https://github.com/ogunkarakus/laravel-cloudflare
+[3]: https://github.com/laravel/laravel/blob/master/app/Http/Middleware/TrustProxies.php
+[4]: https://github.com/fideloper/TrustedProxy

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Add the middleware in `app/Http/Kernel.php`, adding a new line in the `middlewar
 
 ## Existing Laravel application
 
-This middleware uses [fideloper/proxy][4] as a backend, so you can removes the other `TrustProxies` line from the `middleware` array.
+This middleware uses [fideloper/proxy][4] as a backend, so you can remove the other `TrustProxies` line from the `middleware` array.
 
-Another option is to extends the [App\Http\Middleware\TrustProxies.php][3] file to `Monicahq\Cloudflare\Http\Middleware\TrustProxies`:
+Another option is to extend the [App\Http\Middleware\TrustProxies][3] class to `Monicahq\Cloudflare\Http\Middleware\TrustProxies`:
 
 ```php
 namespace App\Http\Middleware;
@@ -39,6 +39,9 @@ class TrustProxies extends Middleware
 {
     ...
 ```
+
+If the cloudflare ips are detected, they will be used, and if not the trustproxies one will be.
+
 
 # Refreshing the Cache
 

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         }
     ],
     "require": {
+        "fideloper/proxy": "~4.0",
         "guzzlehttp/guzzle": "^6.3",
         "illuminate/console": "^5.6",
         "illuminate/http": "^5.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2b9b19a8a18f90ac35cd8b4c83dda5b4",
+    "content-hash": "18b6dc0e813d5dc1e09b67ee38f1af5a",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -278,6 +278,60 @@
                 "parser"
             ],
             "time": "2019-03-17T17:19:46+00:00"
+        },
+        {
+            "name": "fideloper/proxy",
+            "version": "4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fideloper/TrustedProxy.git",
+                "reference": "177c79a2d1f9970f89ee2fb4c12b429af38b6dfb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fideloper/TrustedProxy/zipball/177c79a2d1f9970f89ee2fb4c12b429af38b6dfb",
+                "reference": "177c79a2d1f9970f89ee2fb4c12b429af38b6dfb",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "~5.0",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "illuminate/http": "~5.6",
+                "mockery/mockery": "~1.0",
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Fideloper\\Proxy\\TrustedProxyServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Fideloper\\Proxy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Fidao",
+                    "email": "fideloper@gmail.com"
+                }
+            ],
+            "description": "Set trusted proxies for Laravel",
+            "keywords": [
+                "load balancing",
+                "proxy",
+                "trusted proxy"
+            ],
+            "time": "2019-01-10T14:06:47+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",

--- a/config/laravelcloudflare.php
+++ b/config/laravelcloudflare.php
@@ -1,6 +1,5 @@
 <?php
 
-use Illuminate\Http\Request;
 
 return [
 

--- a/config/laravelcloudflare.php
+++ b/config/laravelcloudflare.php
@@ -6,18 +6,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | The headers that should be used to detect proxies
-    |--------------------------------------------------------------------------
-    |
-    | This header is sent to the server behind.
-    | HEADER_X_FORWARDED_ALL correspond to X-Forwarded-*
-    |
-    */
-
-    'headers' => Request::HEADER_X_FORWARDED_ALL,
-
-    /*
-    |--------------------------------------------------------------------------
     | Name of the cache to store values of the proxies
     |--------------------------------------------------------------------------
     |

--- a/src/Http/Middleware/TrustProxies.php
+++ b/src/Http/Middleware/TrustProxies.php
@@ -18,7 +18,7 @@ class TrustProxies extends Middleware
         $proxies = Cache::get($this->config->get('laravelcloudflare.cache'), []);
 
         if (! empty($proxies)) {
-            $this->$proxies = $proxies;
+            $this->proxies = $proxies;
         }
 
         parent::setTrustedProxyIpAddresses($request);

--- a/src/Http/Middleware/TrustProxies.php
+++ b/src/Http/Middleware/TrustProxies.php
@@ -13,7 +13,7 @@ class TrustProxies extends Middleware
      *
      * @param \Illuminate\Http\Request $request
      */
-    public function setTrustedProxyIpAddresses(Request $request)
+    protected function setTrustedProxyIpAddresses(Request $request)
     {
         $proxies = Cache::get($this->config->get('laravelcloudflare.cache'), []);
 

--- a/tests/Unit/MiddlewareTest.php
+++ b/tests/Unit/MiddlewareTest.php
@@ -9,19 +9,35 @@ use Monicahq\Cloudflare\Http\Middleware\TrustProxies;
 
 class MiddlewareTest extends FeatureTestCase
 {
-    public function test_trust_proxies()
+    public function test_it_sets_trusted_proxies()
     {
         Cache::shouldReceive('get')
             ->with('cloudflare.proxies', [])
             ->andReturn(['expect']);
 
         $request = new Request();
-        (new TrustProxies($this->app->make('config')))->handle($request, function () {
-        });
+
+        (new TrustProxies($this->app->make('config')))->handle($request, function () {});
 
         $this->assertEquals(
             $request->getTrustedProxies(),
             ['expect']
+        );
+    }
+
+    public function test_it_does_not_sets_trusted_proxies()
+    {
+        Cache::shouldReceive('get')
+            ->with('cloudflare.proxies', [])
+            ->andReturn([]);
+
+        $request = new Request();
+
+        (new TrustProxies($this->app->make('config')))->handle($request, function () {});
+
+        $this->assertEquals(
+            $request->getTrustedProxies(),
+            []
         );
     }
 }

--- a/tests/Unit/MiddlewareTest.php
+++ b/tests/Unit/MiddlewareTest.php
@@ -17,7 +17,8 @@ class MiddlewareTest extends FeatureTestCase
 
         $request = new Request();
 
-        (new TrustProxies($this->app->make('config')))->handle($request, function () {});
+        (new TrustProxies($this->app->make('config')))->handle($request, function () {
+        });
 
         $this->assertEquals(
             $request->getTrustedProxies(),
@@ -33,7 +34,8 @@ class MiddlewareTest extends FeatureTestCase
 
         $request = new Request();
 
-        (new TrustProxies($this->app->make('config')))->handle($request, function () {});
+        (new TrustProxies($this->app->make('config')))->handle($request, function () {
+        });
 
         $this->assertEquals(
             $request->getTrustedProxies(),


### PR DESCRIPTION
Use fideloper/proxy package as a backend to set trusted proxies

You can now remove the other TrustProxies line from the middleware array.

Another option is to extends the `App\Http\Middleware\TrustProxies.php` file to `Monicahq\Cloudflare\Http\Middleware\TrustProxies`:
```php
namespace App\Http\Middleware;

use Illuminate\Http\Request;
use Monicahq\Cloudflare\Http\Middleware\TrustProxies as Middleware;

class TrustProxies extends Middleware
{
    ...
```