### PR TITLE
Support laravel 5.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ This file contains some configurations, but you may not need to change them norm
 
 # Support
 
-This package supports Laravel 5.6 or newer.
+This package supports Laravel 5.5 or newer.
 
 # License
 

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,12 @@
         }
     ],
     "require": {
+        "php": ">= 7.1.0",
         "fideloper/proxy": "~4.0",
         "guzzlehttp/guzzle": "^6.3",
-        "illuminate/console": "^5.6",
-        "illuminate/http": "^5.6",
-        "illuminate/support": "^5.6"
+        "illuminate/console": "^5.5",
+        "illuminate/http": "^5.5",
+        "illuminate/support": "^5.5"
     },
     "require-dev": {
         "laravel/framework": "^5.6",


### PR DESCRIPTION
Hi,

Is there a good reason laravel 5.5 was not supported yet? I'm sadly still stuck on 5.5 for a while and like to use this package.

I installed it locally and it seems to work fine.