### PR TITLE
Merge Cloudflare ips with trusted proxies

### DIFF
--- a/src/Http/Middleware/TrustProxies.php
+++ b/src/Http/Middleware/TrustProxies.php
@@ -18,7 +18,7 @@ class TrustProxies extends Middleware
         $proxies = Cache::get($this->config->get('laravelcloudflare.cache'), []);
 
         if (! empty($proxies)) {
-            $this->proxies = $proxies;
+            $this->proxies = array_merge($this->proxies ?? [], $proxies);
         }
 
         parent::setTrustedProxyIpAddresses($request);

--- a/src/Http/Middleware/TrustProxies.php
+++ b/src/Http/Middleware/TrustProxies.php
@@ -18,7 +18,7 @@ class TrustProxies extends Middleware
         $proxies = Cache::get($this->config->get('laravelcloudflare.cache'), []);
 
         if (! empty($proxies)) {
-            $this->proxies = array_merge($this->proxies ?? [], $proxies);
+            $this->proxies = array_merge((array) $this->proxies, $proxies);
         }
 
         parent::setTrustedProxyIpAddresses($request);


### PR DESCRIPTION
This PR merges the IPs from CloudFlare with the `$proxies` set in the middelware.

Resolves #175 