### PR TITLE
Fix test

### DIFF
--- a/tests/FeatureTestCase.php
+++ b/tests/FeatureTestCase.php
@@ -2,11 +2,17 @@
 
 namespace Monicahq\Cloudflare\Tests;
 
+use Illuminate\Http\Request;
 use Monicahq\Cloudflare\TrustedProxyServiceProvider;
 use Orchestra\Testbench\TestCase;
 
 class FeatureTestCase extends TestCase
 {
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('trustedproxy.headers', Request::HEADER_X_FORWARDED_ALL);
+    }
+
     protected function getPackageProviders($app)
     {
         return [


### PR DESCRIPTION
The `$headers` property is not set when running the tests.
This PR fixes this by setting the `trustedproxy.headers` config value.

Pulling this in will also let the tests pass in PR #193, which will allow `guzzlehttp/guzzle:^7.0` 