### PR TITLE
feat: use laravel Http factory and remove guzzle dependency

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         php-version: [7.3, 7.4, 8.0]
-        illuminate_version: [6.*, 7.*, 8.*]
+        illuminate_version: [7.*, 8.*]
         composer_flags:  ['', '--prefer-lowest']
     name: PHP ${{ matrix.php-version }} | Illuminate ${{ matrix.illuminate_version }} ${{ matrix.composer_flags }}
 

--- a/README.md
+++ b/README.md
@@ -83,9 +83,13 @@ php artisan vendor:publish --provider="Monicahq\Cloudflare\TrustedProxyServicePr
 
 This file contains some configurations, but you may not need to change them normally.
 
-# Support
+# Compatibility
 
-This package supports Laravel 5.5 or newer.
+| Laravel | [monicahq/laravel-cloudflare](https://github.com/monicahq/laravel-cloudflare) |
+|---------|----------|
+| 5.x-6.x | <= 1.8.0 |
+| 7.x-8.x | >= 2.0.0 |
+
 
 # Citations
 
@@ -98,6 +102,6 @@ Author: [Alexis Saettler](https://github.com/asbiin)
 
 This project is part of [MonicaHQ](https://github.com/monicahq/).
 
-Copyright (c) 2019-2020.
+Copyright (c) 2019-2021.
 
 Licensed under the MIT License. [View license](LICENSE.md).

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,13 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "fideloper/proxy": "^4.4",
-        "illuminate/console": "^5.5 || ^6.0 || ^7.0 || ^8.0",
-        "illuminate/http": "^5.5 || ^6.0 || ^7.0 || ^8.0",
-        "illuminate/support": "^5.5 || ^6.0 || ^7.0 || ^8.0"
+        "illuminate/console": "^7.0 || ^8.0",
+        "illuminate/http": "^7.0 || ^8.0",
+        "illuminate/support": "^7.0 || ^8.0"
     },
     "require-dev": {
-        "laravel/framework": "^5.5 || ^6.0 || ^7.0 || ^8.0",
+        "guzzlehttp/guzzle": "^6.3 || ^7.0",
+        "laravel/framework": "^7.0 || ^8.0",
         "mockery/mockery": "^1.4",
         "nunomaduro/larastan": "^0",
         "ocramius/package-versions": "^1.5 || ^2.1",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "fideloper/proxy": "^4.4",
-        "guzzlehttp/guzzle": "^6.3 || ^7.0",
         "illuminate/console": "^5.5 || ^6.0 || ^7.0 || ^8.0",
         "illuminate/http": "^5.5 || ^6.0 || ^7.0 || ^8.0",
         "illuminate/support": "^5.5 || ^6.0 || ^7.0 || ^8.0"

--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,9 @@
             ]
         }
     },
+    "suggest": {
+        "guzzlehttp/guzzle": "Required to get cloudflares ip addresses (^6.5.5|^7.0.1)."
+    },
     "config": {
         "sort-packages": true
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,26 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Tests">
-            <directory suffix="Test.php">./tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="APP_ENV" value="testing"/>
-        <env name="APP_KEY" value="base64:uA/XEme0vpegJz/rKSk3ys2uzEfXZA0Ca2P0e1M8vRU="/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Tests">
+      <directory suffix="Test.php">./tests/</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="APP_ENV" value="testing"/>
+    <env name="APP_KEY" value="base64:uA/XEme0vpegJz/rKSk3ys2uzEfXZA0Ca2P0e1M8vRU="/>
+  </php>
 </phpunit>

--- a/src/CloudflareProxies.php
+++ b/src/CloudflareProxies.php
@@ -4,7 +4,7 @@ namespace Monicahq\Cloudflare;
 
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Support\Str;
-use Illuminate\Http\Client\Factory as HttpClient;
+use Illuminate\Support\Facades\Http;
 use UnexpectedValueException;
 
 class CloudflareProxies
@@ -23,22 +23,13 @@ class CloudflareProxies
     protected $config;
 
     /**
-     * The http factory instance.
-     *
-     * @var HttpClient
-     */
-    protected $http;
-
-    /**
      * Create a new instance of CloudflareProxies.
      *
      * @param \Illuminate\Contracts\Config\Repository $config
-     * @param \Illuminate\Http\Client\Factory $http
      */
-    public function __construct(Repository $config, HttpClient $http)
+    public function __construct(Repository $config)
     {
         $this->config = $config;
-        $this->http = $http;
     }
 
     /**
@@ -74,15 +65,15 @@ class CloudflareProxies
         try {
             $url = Str::of($this->config->get('laravelcloudflare.url'))->finish('/').$name;
 
-            $response = $this->http->get($url);
+            $response = Http::get($url);
         } catch (\Exception $e) {
             throw new UnexpectedValueException('Failed to load trust proxies from Cloudflare server.', 1, $e);
         }
 
-        if ($response->getStatusCode() != 200) {
+        if ($response->status() != 200) {
             throw new UnexpectedValueException('Failed to load trust proxies from Cloudflare server.');
         }
 
-        return array_filter(explode("\n", (string) $response->getBody()));
+        return array_filter(explode("\n", $response->body()));
     }
 }

--- a/src/CloudflareProxies.php
+++ b/src/CloudflareProxies.php
@@ -2,8 +2,9 @@
 
 namespace Monicahq\Cloudflare;
 
-use GuzzleHttp\Client as GuzzleClient;
 use Illuminate\Contracts\Config\Repository;
+use Illuminate\Support\Str;
+use Illuminate\Http\Client\Factory as HttpClient;
 use UnexpectedValueException;
 
 class CloudflareProxies
@@ -17,27 +18,27 @@ class CloudflareProxies
     /**
      * The config repository instance.
      *
-     * @var \Illuminate\Contracts\Config\Repository
+     * @var Repository
      */
     protected $config;
 
     /**
-     * The GuzzleClient used to make requests.
+     * The http factory instance.
      *
-     * @var GuzzleClient
+     * @var HttpClient
      */
-    protected $client;
+    protected $http;
 
     /**
      * Create a new instance of CloudflareProxies.
      *
      * @param \Illuminate\Contracts\Config\Repository $config
-     * @param GuzzleClient  $client  Client used for http request
+     * @param \Illuminate\Http\Client\Factory $http
      */
-    public function __construct(Repository $config, GuzzleClient $client = null)
+    public function __construct(Repository $config, HttpClient $http)
     {
         $this->config = $config;
-        $this->client = $client ?? new GuzzleClient();
+        $this->http = $http;
     }
 
     /**
@@ -71,9 +72,9 @@ class CloudflareProxies
     protected function retrieve($name): array
     {
         try {
-            $url = $this->config->get('laravelcloudflare.url').'/'.$name;
+            $url = Str::of($this->config->get('laravelcloudflare.url'))->finish('/').$name;
 
-            $response = $this->client->request('GET', $url);
+            $response = $this->http->get($url);
         } catch (\Exception $e) {
             throw new UnexpectedValueException('Failed to load trust proxies from Cloudflare server.', 1, $e);
         }

--- a/src/CloudflareProxies.php
+++ b/src/CloudflareProxies.php
@@ -3,8 +3,8 @@
 namespace Monicahq\Cloudflare;
 
 use Illuminate\Contracts\Config\Repository;
-use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
 use UnexpectedValueException;
 
 class CloudflareProxies

--- a/src/CloudflareProxies.php
+++ b/src/CloudflareProxies.php
@@ -3,8 +3,8 @@
 namespace Monicahq\Cloudflare;
 
 use Illuminate\Contracts\Config\Repository;
-use Illuminate\Support\Str;
 use Illuminate\Http\Client\Factory as HttpClient;
+use Illuminate\Support\Str;
 use UnexpectedValueException;
 
 class CloudflareProxies

--- a/src/CloudflareProxies.php
+++ b/src/CloudflareProxies.php
@@ -3,8 +3,8 @@
 namespace Monicahq\Cloudflare;
 
 use Illuminate\Contracts\Config\Repository;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
+use Illuminate\Http\Client\Factory as HttpClient;
 use UnexpectedValueException;
 
 class CloudflareProxies
@@ -23,13 +23,22 @@ class CloudflareProxies
     protected $config;
 
     /**
+     * The http factory instance.
+     *
+     * @var HttpClient
+     */
+    protected $http;
+
+    /**
      * Create a new instance of CloudflareProxies.
      *
      * @param \Illuminate\Contracts\Config\Repository $config
+     * @param \Illuminate\Http\Client\Factory $http
      */
-    public function __construct(Repository $config)
+    public function __construct(Repository $config, HttpClient $http)
     {
         $this->config = $config;
+        $this->http = $http;
     }
 
     /**
@@ -65,7 +74,7 @@ class CloudflareProxies
         try {
             $url = Str::of($this->config->get('laravelcloudflare.url'))->finish('/').$name;
 
-            $response = Http::get($url);
+            $response = $this->http->get($url);
         } catch (\Exception $e) {
             throw new UnexpectedValueException('Failed to load trust proxies from Cloudflare server.', 1, $e);
         }

--- a/src/Commands/Reload.php
+++ b/src/Commands/Reload.php
@@ -18,7 +18,7 @@ class Reload extends Command
     /**
      * The console command description.
      *
-     * @var string|null
+     * @var string
      */
     protected $description = 'Reload trust proxies IPs and store in cache.';
 

--- a/src/Commands/View.php
+++ b/src/Commands/View.php
@@ -17,7 +17,7 @@ class View extends Command
     /**
      * The console command description.
      *
-     * @var string|null
+     * @var string
      */
     protected $description = 'View list of trust proxies IPs stored in cache.';
 

--- a/src/TrustedProxyServiceProvider.php
+++ b/src/TrustedProxyServiceProvider.php
@@ -3,6 +3,8 @@
 namespace Monicahq\Cloudflare;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Config\Repository;
+use Illuminate\Http\Client\Factory as HttpClient;
 
 class TrustedProxyServiceProvider extends ServiceProvider
 {
@@ -46,7 +48,7 @@ class TrustedProxyServiceProvider extends ServiceProvider
 
         if ($app->runningInConsole()) {
             $app->singleton(CloudflareProxies::class, function ($app): CloudflareProxies {
-                return new CloudflareProxies($app->make('config'));
+                return new CloudflareProxies($app->make(Repository::class), $app->make(HttpClient::class));
             });
 
             $this->commands([

--- a/src/TrustedProxyServiceProvider.php
+++ b/src/TrustedProxyServiceProvider.php
@@ -3,8 +3,6 @@
 namespace Monicahq\Cloudflare;
 
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Contracts\Config\Repository;
-use Illuminate\Http\Client\Factory as HttpClient;
 
 class TrustedProxyServiceProvider extends ServiceProvider
 {
@@ -43,14 +41,7 @@ class TrustedProxyServiceProvider extends ServiceProvider
             __DIR__.'/../config/laravelcloudflare.php', 'laravelcloudflare'
         );
 
-        /** @var \Illuminate\Contracts\Foundation\Application */
-        $app = $this->app;
-
-        if ($app->runningInConsole()) {
-            $app->singleton(CloudflareProxies::class, function ($app): CloudflareProxies {
-                return new CloudflareProxies($app->make(Repository::class), $app->make(HttpClient::class));
-            });
-
+        if ($this->app->runningInConsole()) {
             $this->commands([
                 Commands\Reload::class,
                 Commands\View::class,

--- a/tests/Unit/MiddlewareTest.php
+++ b/tests/Unit/MiddlewareTest.php
@@ -9,7 +9,8 @@ use Monicahq\Cloudflare\Tests\FeatureTestCase;
 
 class MiddlewareTest extends FeatureTestCase
 {
-    public function test_it_sets_trusted_proxies()
+    /** @test */
+    public function it_sets_trusted_proxies()
     {
         Cache::shouldReceive('get')
             ->with('cloudflare.proxies', [])
@@ -25,7 +26,8 @@ class MiddlewareTest extends FeatureTestCase
         );
     }
 
-    public function test_it_does_not_sets_trusted_proxies()
+    /** @test */
+    public function it_does_not_sets_trusted_proxies()
     {
         Cache::shouldReceive('get')
             ->with('cloudflare.proxies', [])

--- a/tests/Unit/MiddlewareTest.php
+++ b/tests/Unit/MiddlewareTest.php
@@ -17,8 +17,7 @@ class MiddlewareTest extends FeatureTestCase
 
         $request = new Request();
 
-        (new TrustProxies($this->app->make('config')))->handle($request, function () {
-        });
+        $this->app->make(TrustProxies::class)->handle($request, function () {});
 
         $this->assertEquals(
             $request->getTrustedProxies(),
@@ -34,8 +33,7 @@ class MiddlewareTest extends FeatureTestCase
 
         $request = new Request();
 
-        (new TrustProxies($this->app->make('config')))->handle($request, function () {
-        });
+        $this->app->make(TrustProxies::class)->handle($request, function () {});
 
         $this->assertEquals(
             $request->getTrustedProxies(),

--- a/tests/Unit/ReloadCommandTest.php
+++ b/tests/Unit/ReloadCommandTest.php
@@ -2,12 +2,9 @@
 
 namespace Monicahq\Cloudflare\Tests\Unit;
 
-use Illuminate\Support\Facades\Http;
-use Monicahq\Cloudflare\CloudflareProxies;
-use Monicahq\Cloudflare\Tests\FeatureTestCase;
 use Illuminate\Http\Client\Factory as HttpClient;
-use Illuminate\Support\Facades\Cache;
-use UnexpectedValueException;
+use Illuminate\Support\Facades\Http;
+use Monicahq\Cloudflare\Tests\FeatureTestCase;
 
 class ReloadCommandTest extends FeatureTestCase
 {

--- a/tests/Unit/ReloadCommandTest.php
+++ b/tests/Unit/ReloadCommandTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Monicahq\Cloudflare\Tests\Unit;
+
+use Illuminate\Support\Facades\Http;
+use Monicahq\Cloudflare\CloudflareProxies;
+use Monicahq\Cloudflare\Tests\FeatureTestCase;
+use Illuminate\Http\Client\Factory as HttpClient;
+use Illuminate\Support\Facades\Cache;
+use UnexpectedValueException;
+
+class ReloadCommandTest extends FeatureTestCase
+{
+    /** @test */
+    public function it_saves_address_in_cache()
+    {
+        $this->app['config']->set('laravelcloudflare.url', 'https://fake');
+        $this->app[HttpClient::class] = Http::fake([
+            'https://fake/ips-v4' => Http::response('0.0.0.0/20', 200),
+            'https://fake/ips-v6' => Http::response('::1/32', 200),
+        ]);
+
+        $this->withoutMockingConsoleOutput();
+
+        $this->artisan('cloudflare:reload');
+
+        $this->assertEquals(['0.0.0.0/20', '::1/32'], $this->app['cache']->get('cloudflare.proxies'));
+    }
+}


### PR DESCRIPTION

BREAKING CHANGES: CloudflareProxies constructor has change, this should not have an impact if you don't extend it. This version also removes Illuminate < 6.x compatibility.