### PR TITLE
feat: remove fideloper/proxy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "fideloper/proxy": "^4.4",
         "illuminate/console": "^7.0 || ^8.0",
         "illuminate/http": "^7.0 || ^8.0",
         "illuminate/support": "^7.0 || ^8.0"

--- a/src/Http/Middleware/TrustProxies.php
+++ b/src/Http/Middleware/TrustProxies.php
@@ -24,3 +24,4 @@ class TrustProxies extends Middleware
         parent::setTrustedProxyIpAddresses($request);
     }
 }
+

--- a/src/Http/Middleware/TrustProxies.php
+++ b/src/Http/Middleware/TrustProxies.php
@@ -2,7 +2,7 @@
 
 namespace Monicahq\Cloudflare\Http\Middleware;
 
-use Fideloper\Proxy\TrustProxies as Middleware;
+use Illuminate\Http\Middleware\TrustProxies as Middleware;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 
@@ -15,7 +15,7 @@ class TrustProxies extends Middleware
      */
     protected function setTrustedProxyIpAddresses(Request $request)
     {
-        $proxies = Cache::get($this->config->get('laravelcloudflare.cache'), []);
+        $proxies = Cache::get(config('laravelcloudflare.cache'), []);
 
         if (is_array($proxies) && count($proxies) > 0) {
             $this->proxies = array_merge((array) $this->proxies, $proxies);

--- a/src/Http/Middleware/TrustProxies.php
+++ b/src/Http/Middleware/TrustProxies.php
@@ -24,4 +24,3 @@ class TrustProxies extends Middleware
         parent::setTrustedProxyIpAddresses($request);
     }
 }
-


### PR DESCRIPTION
closes https://github.com/monicahq/laravel-cloudflare/issues/224


I think it would be best to create a new version  of this package, 3.0.0?

This is recently changed in Larvavel >= v8.5.24