### PR TITLE
feat: add a customisable callback to get proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,28 @@ Another option is to extend the `App\Http\Middleware\TrustProxies` class to `Mon
       ...
 ```
 
+## Custom proxies callback
+
+You can define your own proxies callback by calling the `LaravelCloudflare::getProxiesUsing()` to change the behavior of the `LaravelCloudflare::getProxies()` method.
+This method should typically be called in the `boot` method of your `AppServiceProvider` class:
+
+```php
+use Monicahq\Cloudflare\LaravelCloudflare;
+use Monicahq\Cloudflare\Facades\CloudflareProxies;
+
+/**
+ * Bootstrap any application services.
+ *
+ * @return void
+ */
+public function boot()
+{
+    LaravelCloudflare::getProxiesUsing(function() {
+        return CloudflareProxies::load();
+    });
+}
+```
+
 
 # How it works
 

--- a/src/Commands/Reload.php
+++ b/src/Commands/Reload.php
@@ -5,7 +5,7 @@ namespace Monicahq\Cloudflare\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Cache\Factory;
 use Illuminate\Contracts\Config\Repository;
-use Monicahq\Cloudflare\CloudflareProxies;
+use Monicahq\Cloudflare\LaravelCloudflare;
 
 class Reload extends Command
 {
@@ -32,10 +32,9 @@ class Reload extends Command
      */
     public function handle(Factory $cache, Repository $config)
     {
-        /** @var CloudflareProxies */
-        $loader = $this->laravel->make(CloudflareProxies::class);
+        $proxies = LaravelCloudflare::getProxies();
 
-        $cache->store()->forever($config->get('laravelcloudflare.cache'), $loader->load());
+        $cache->store()->forever($config->get('laravelcloudflare.cache'), $proxies);
 
         $this->info('Cloudflare\'s IP blocks have been reloaded.');
     }

--- a/src/Facades/CloudflareProxies.php
+++ b/src/Facades/CloudflareProxies.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Monicahq\Cloudflare\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * @method static function array load(int $type = \Monicahq\Cloudflare\CloudflareProxies::IP_VERSION_ANY)
+ *
+ * @see \Monicahq\Cloudflare\CloudflareProxies
+ */
+class CloudflareProxies extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return \Monicahq\Cloudflare\CloudflareProxies::class;
+    }
+}

--- a/src/Facades/CloudflareProxies.php
+++ b/src/Facades/CloudflareProxies.php
@@ -5,7 +5,7 @@ namespace Monicahq\Cloudflare\Facades;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @method static function array load(int $type = \Monicahq\Cloudflare\CloudflareProxies::IP_VERSION_ANY)
+ * @method static array load(int $type = \Monicahq\Cloudflare\CloudflareProxies::IP_VERSION_ANY)
  *
  * @see \Monicahq\Cloudflare\CloudflareProxies
  */

--- a/src/Http/Middleware/TrustProxies.php
+++ b/src/Http/Middleware/TrustProxies.php
@@ -6,7 +6,7 @@ use Illuminate\Http\Middleware\TrustProxies as Middleware;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
-use Monicahq\Cloudflare\CloudflareProxies;
+use Monicahq\Cloudflare\LaravelCloudflare;
 
 class TrustProxies extends Middleware
 {
@@ -18,10 +18,7 @@ class TrustProxies extends Middleware
     protected function setTrustedProxyIpAddresses(Request $request)
     {
         $cachedProxies = Cache::get(Config::get('laravelcloudflare.cache'), function () {
-            /** @var CloudflareProxies $cloudflareProxies */
-            $cloudflareProxies = app(CloudflareProxies::class);
-
-            return $cloudflareProxies->load();
+            return LaravelCloudflare::getProxies();
         });
 
         if (is_array($cachedProxies) && count($cachedProxies) > 0) {

--- a/src/LaravelCloudflare.php
+++ b/src/LaravelCloudflare.php
@@ -20,7 +20,7 @@ final class LaravelCloudflare
      */
     public static function getProxies(): array
     {
-        if (static::$getProxiesCallback) {
+        if (static::$getProxiesCallback !== null) {
             return call_user_func(static::$getProxiesCallback);
         }
 

--- a/src/LaravelCloudflare.php
+++ b/src/LaravelCloudflare.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Monicahq\Cloudflare;
+
+use Monicahq\Cloudflare\Facades\CloudflareProxies;
+
+final class LaravelCloudflare
+{
+    /**
+     * The callback that should be used to get the proxies addresses.
+     *
+     * @var \Closure|null
+     */
+    protected static $getProxiesCallback;
+
+    /**
+     * Get the proxies addresses.
+     *
+     * @return array
+     */
+    public static function getProxies(): array
+    {
+        if (static::$getProxiesCallback) {
+            return call_user_func(static::$getProxiesCallback);
+        }
+
+        return CloudflareProxies::load();
+    }
+
+    /**
+     * Set a callback that should be used when getting the proxies addresses.
+     *
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public static function getProxiesUsing($callback): void
+    {
+        static::$getProxiesCallback = $callback;
+    }
+}

--- a/src/TrustedProxyServiceProvider.php
+++ b/src/TrustedProxyServiceProvider.php
@@ -40,6 +40,7 @@ class TrustedProxyServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(
             __DIR__.'/../config/laravelcloudflare.php', 'laravelcloudflare'
         );
+        $this->app->singleton(\Monicahq\Cloudflare\Facades\CloudflareProxies::class, \Monicahq\Cloudflare\CloudflareProxies::class);
 
         if ($this->app->runningInConsole()) {
             $this->commands([

--- a/tests/Unit/Commands/ReloadTest.php
+++ b/tests/Unit/Commands/ReloadTest.php
@@ -4,8 +4,7 @@ namespace Monicahq\Cloudflare\Tests\Unit\Commands;
 
 use Illuminate\Http\Client\Factory as HttpClient;
 use Illuminate\Support\Facades\Http;
-use Mockery\MockInterface;
-use Monicahq\Cloudflare\CloudflareProxies;
+use Monicahq\Cloudflare\Facades\CloudflareProxies;
 use Monicahq\Cloudflare\Tests\FeatureTestCase;
 
 class ReloadTest extends FeatureTestCase
@@ -13,10 +12,9 @@ class ReloadTest extends FeatureTestCase
     /** @test */
     public function it_loads_proxies()
     {
-        $this->mock(CloudflareProxies::class, function (MockInterface $mock) {
-            $mock->shouldReceive('load')
-                ->andReturn(['expect']);
-        });
+        CloudflareProxies::shouldReceive('load')
+            ->once()
+            ->andReturn(['expect']);
 
         $this->artisan('cloudflare:reload')
             ->expectsOutput('Cloudflare\'s IP blocks have been reloaded.')

--- a/tests/Unit/Http/Middleware/TrustProxiesTest.php
+++ b/tests/Unit/Http/Middleware/TrustProxiesTest.php
@@ -4,8 +4,7 @@ namespace Monicahq\Cloudflare\Tests\Unit\Http\Middleware;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
-use Mockery\MockInterface;
-use Monicahq\Cloudflare\CloudflareProxies;
+use Monicahq\Cloudflare\Facades\CloudflareProxies;
 use Monicahq\Cloudflare\Http\Middleware\TrustProxies;
 use Monicahq\Cloudflare\Tests\FeatureTestCase;
 
@@ -48,10 +47,9 @@ class TrustProxiesTest extends FeatureTestCase
     /** @test */
     public function it_load_trustproxies()
     {
-        $this->mock(CloudflareProxies::class, function (MockInterface $mock) {
-            $mock->shouldReceive('load')
-                ->andReturn(['expect']);
-        });
+        CloudflareProxies::shouldReceive('load')
+            ->once()
+            ->andReturn(['expect']);
 
         $request = new Request();
 

--- a/tests/Unit/LaravelCloudflareTest.php
+++ b/tests/Unit/LaravelCloudflareTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Monicahq\Cloudflare\Tests\Unit;
+
+use Illuminate\Http\Request;
+use Monicahq\Cloudflare\Http\Middleware\TrustProxies;
+use Monicahq\Cloudflare\LaravelCloudflare;
+use Monicahq\Cloudflare\Tests\FeatureTestCase;
+
+class LaravelCloudflareTest extends FeatureTestCase
+{
+    private static bool $run;
+
+    /** @test */
+    public function it_call_callback()
+    {
+        static::$run = false;
+
+        LaravelCloudflare::getProxiesUsing(function() {
+            static::$run = true;
+            return ['expect'];
+        });
+
+        $request = new Request();
+
+        $this->app->make(TrustProxies::class)->handle($request, function () {
+        });
+
+        $proxies = $request->getTrustedProxies();
+
+        $this->assertTrue(static::$run);
+        $this->assertEquals(['expect'], $proxies);
+    }
+}

--- a/tests/Unit/LaravelCloudflareTest.php
+++ b/tests/Unit/LaravelCloudflareTest.php
@@ -16,8 +16,9 @@ class LaravelCloudflareTest extends FeatureTestCase
     {
         static::$run = false;
 
-        LaravelCloudflare::getProxiesUsing(function() {
+        LaravelCloudflare::getProxiesUsing(function () {
             static::$run = true;
+
             return ['expect'];
         });
 


### PR DESCRIPTION
This adds a static class `LaravelCloudflare` where you can define your own callback to get proxies.
Add this in the  `boot` method of your `AppServiceProvider` class:

```php
use Monicahq\Cloudflare\LaravelCloudflare;
use Monicahq\Cloudflare\Facades\CloudflareProxies;

/**
 * Bootstrap any application services.
 *
 * @return void
 */
public function boot()
{
    LaravelCloudflare::getProxiesUsing(function() {
        // Change behavior of the method here...
        return CloudflareProxies::load();
    });
}
```