### PR TITLE
fix: merge config only if configuration is not cached

### DIFF
--- a/src/TrustedProxyServiceProvider.php
+++ b/src/TrustedProxyServiceProvider.php
@@ -37,9 +37,12 @@ class TrustedProxyServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->mergeConfigFrom(
-            __DIR__.'/../config/laravelcloudflare.php', 'laravelcloudflare'
-        );
+        if (! app()->configurationIsCached()) {
+            $this->mergeConfigFrom(
+                __DIR__.'/../config/laravelcloudflare.php', 'laravelcloudflare'
+            );
+        }
+
         $this->app->singleton(\Monicahq\Cloudflare\Facades\CloudflareProxies::class, \Monicahq\Cloudflare\CloudflareProxies::class);
 
         if ($this->app->runningInConsole()) {

--- a/src/TrustedProxyServiceProvider.php
+++ b/src/TrustedProxyServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Monicahq\Cloudflare;
 
+use Illuminate\Contracts\Foundation\CachesConfiguration;
 use Illuminate\Support\ServiceProvider;
 
 class TrustedProxyServiceProvider extends ServiceProvider
@@ -37,7 +38,7 @@ class TrustedProxyServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        if (! app()->configurationIsCached()) {
+        if (! ($this->app instanceof CachesConfiguration && $this->app->configurationIsCached())) {
             $this->mergeConfigFrom(
                 __DIR__.'/../config/laravelcloudflare.php', 'laravelcloudflare'
             );


### PR DESCRIPTION
Merge config only if configuration is not cached