### PR TITLE
feat!: Remove support for Laravel 9 and 10

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -10,4 +10,3 @@ jobs:
     uses: monicahq/workflows/.github/workflows/static.yml@v2
     with:
       php-version: 8.4
-      with: phpstan

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,11 +26,11 @@ jobs:
     name: Run tests
     uses: monicahq/workflows/.github/workflows/library.yml@v2
     with:
-      php-versions: "['8.1', '8.2', '8.3', '8.4']"
-      laravel-versions: "['^9.0', '^10.0', '^11.0', '^12.0']"
+      php-versions: "['8.2', '8.3', '8.4']"
+      laravel-versions: "['^11.0', '^12.0']"
       default-php-version: '8.4'
       default-laravel-version: '^12.0'
-      matrix-exclude: "[{'php-version': '8.1', 'laravel-version': '^11.0'},{'php-version': '8.1', 'laravel-version': '^12.0'}]"
+      matrix-exclude: "[]"
       project: monicahq_laravel-cloudflare
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -116,9 +116,10 @@ LARAVEL_CLOUDFLARE_ENABLED=false
 
 | Laravel  | [monicahq/laravel-cloudflare](https://github.com/monicahq/laravel-cloudflare) |
 |----------|----------|
-| 5.x-6.x  | <= 1.8.0 |
-| 7.x-8.53 |  2.0.0   |
-| >= 8.54 | >= 3.0.0 |
+| 5.x-6.x  | <= 1.8 |
+| 7.x-8.53 |  2.x   |
+| 8.54-12.0 | 3.x |
+| >= 11.0 | >= 4.x |
 
 
 # Citations
@@ -132,6 +133,6 @@ Author: [Alexis Saettler](https://github.com/asbiin)
 
 This project is part of [MonicaHQ](https://github.com/monicahq/).
 
-Copyright © 2019–2024.
+Copyright © 2019–2025.
 
 Licensed under the MIT License. [View license](LICENSE.md).

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "phpstan/phpstan-phpunit": "^1.0 || ^2.0",
         "phpstan/phpstan-strict-rules": "^1.0 || ^2.0",
         "phpunit/phpunit": "^10.0 || ^11.0",
-        "vimeo/psalm": "^5.6 || ^6.0"
+        "vimeo/psalm": "^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,22 +20,22 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
-        "illuminate/support": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0"
+        "php": "^8.2",
+        "illuminate/support": "^11.0 || ^12.0"
     },
     "require-dev": {
         "brainmaestro/composer-git-hooks": "^3.0",
         "guzzlehttp/guzzle": "^6.3 || ^7.0",
-        "larastan/larastan": "^1.0 || ^2.4 || ^3.0",
+        "larastan/larastan": "^2.4 || ^3.0",
         "laravel/pint": "^1.15",
         "mockery/mockery": "^1.4",
         "ocramius/package-versions": "^1.5 || ^2.1",
-        "orchestra/testbench": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0",
+        "orchestra/testbench": "^9.0 || ^10.0",
         "phpstan/phpstan-deprecation-rules": "^1.0 || ^2.0",
         "phpstan/phpstan-phpunit": "^1.0 || ^2.0",
         "phpstan/phpstan-strict-rules": "^1.0 || ^2.0",
-        "phpunit/phpunit": "^9.5 || ^10.0 || ^11.0",
-        "vimeo/psalm": "^4.0 || ^5.6 || ^6.0"
+        "phpunit/phpunit": "^10.0 || ^11.0",
+        "vimeo/psalm": "^5.6 || ^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/psalm.xml
+++ b/psalm.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
-    findUnusedBaselineEntry="true"
+    findUnusedBaselineEntry="false"
     findUnusedCode="false"
 >
     <projectFiles>
@@ -35,6 +35,12 @@
                 <file name="src/Http/Middleware/TrustProxies.php" />
             </errorLevel>
         </ClassMustBeFinal>
+
+        <MissingClassConstType>
+            <errorLevel type="suppress">
+                <file name="src/CloudflareProxies.php" />
+            </errorLevel>
+        </MissingClassConstType>
 
     </issueHandlers>
 </psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -31,6 +31,7 @@
 
         <ClassMustBeFinal>
             <errorLevel type="suppress">
+                <file name="src/CloudflareProxies.php" />
                 <file name="src/Http/Middleware/TrustProxies.php" />
             </errorLevel>
         </ClassMustBeFinal>

--- a/psalm.xml
+++ b/psalm.xml
@@ -29,11 +29,11 @@
             </errorLevel>
         </MissingClosureParamType>
 
-        <MissingClassConstType>
+        <ClassMustBeFinal>
             <errorLevel type="suppress">
-                <file name="src/CloudflareProxies.php" />
+                <file name="src/Http/Middleware/TrustProxies.php" />
             </errorLevel>
-        </MissingClassConstType>
+        </ClassMustBeFinal>
 
     </issueHandlers>
 </psalm>

--- a/src/CloudflareProxies.php
+++ b/src/CloudflareProxies.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use UnexpectedValueException;
 
-final class CloudflareProxies
+class CloudflareProxies
 {
     /**
      * Use IPv4 addresses.

--- a/src/CloudflareProxies.php
+++ b/src/CloudflareProxies.php
@@ -12,18 +12,24 @@ class CloudflareProxies
 {
     /**
      * Use IPv4 addresses.
+     *
+     * @var int
      */
-    public const int IP_VERSION_4 = 1 << 0;
+    public const IP_VERSION_4 = 1 << 0;
 
     /**
      * Use IPv6 addresses.
+     *
+     * @var int
      */
-    public const int IP_VERSION_6 = 1 << 1;
+    public const IP_VERSION_6 = 1 << 1;
 
     /**
      * Use any IP addresses.
+     *
+     * @var int
      */
-    public const int IP_VERSION_ANY = self::IP_VERSION_4 | self::IP_VERSION_6;
+    public const IP_VERSION_ANY = self::IP_VERSION_4 | self::IP_VERSION_6;
 
     /**
      * Create a new instance of CloudflareProxies.

--- a/src/CloudflareProxies.php
+++ b/src/CloudflareProxies.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use UnexpectedValueException;
 
-class CloudflareProxies
+final class CloudflareProxies
 {
     /**
      * Use IPv4 addresses.
@@ -64,7 +64,7 @@ class CloudflareProxies
     protected function retrieve(string $name): array
     {
         try {
-            $url = Str::of($this->config->get('laravelcloudflare.url', 'https://www.cloudflare.com/'))->finish('/').$name;
+            $url = ((string) Str::of($this->config->get('laravelcloudflare.url', 'https://www.cloudflare.com/'))->finish('/')).$name;
 
             $response = Http::get($url)->throw();
         } catch (\Exception $e) {

--- a/src/CloudflareProxies.php
+++ b/src/CloudflareProxies.php
@@ -12,24 +12,18 @@ class CloudflareProxies
 {
     /**
      * Use IPv4 addresses.
-     *
-     * @var int
      */
-    public const IP_VERSION_4 = 1 << 0;
+    public const int IP_VERSION_4 = 1 << 0;
 
     /**
      * Use IPv6 addresses.
-     *
-     * @var int
      */
-    public const IP_VERSION_6 = 1 << 1;
+    public const int IP_VERSION_6 = 1 << 1;
 
     /**
      * Use any IP addresses.
-     *
-     * @var int
      */
-    public const IP_VERSION_ANY = self::IP_VERSION_4 | self::IP_VERSION_6;
+    public const int IP_VERSION_ANY = self::IP_VERSION_4 | self::IP_VERSION_6;
 
     /**
      * Create a new instance of CloudflareProxies.

--- a/src/Commands/Reload.php
+++ b/src/Commands/Reload.php
@@ -7,7 +7,7 @@ use Illuminate\Contracts\Cache\Factory as Cache;
 use Illuminate\Contracts\Config\Repository as Config;
 use Monicahq\Cloudflare\LaravelCloudflare;
 
-class Reload extends Command
+final class Reload extends Command
 {
     /**
      * The name and signature of the console command.

--- a/src/Commands/Reload.php
+++ b/src/Commands/Reload.php
@@ -19,7 +19,7 @@ class Reload extends Command
     /**
      * The console command description.
      *
-     * @var string|null
+     * @var string
      */
     protected $description = 'Reload trust proxies IPs and store in cache.';
 

--- a/src/Commands/View.php
+++ b/src/Commands/View.php
@@ -6,7 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Contracts\Cache\Factory as Cache;
 use Illuminate\Contracts\Config\Repository as Config;
 
-class View extends Command
+final class View extends Command
 {
     /**
      * The name and signature of the console command.

--- a/src/Commands/View.php
+++ b/src/Commands/View.php
@@ -18,7 +18,7 @@ class View extends Command
     /**
      * The console command description.
      *
-     * @var string|null
+     * @var string
      */
     protected $description = 'View list of trust proxies IPs stored in cache.';
 

--- a/src/Facades/CloudflareProxies.php
+++ b/src/Facades/CloudflareProxies.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Facade;
  *
  * @see \Monicahq\Cloudflare\CloudflareProxies
  */
-class CloudflareProxies extends Facade
+final class CloudflareProxies extends Facade
 {
     /**
      * Get the registered name of the component.

--- a/src/Http/Middleware/TrustProxies.php
+++ b/src/Http/Middleware/TrustProxies.php
@@ -16,6 +16,7 @@ class TrustProxies extends Middleware
      *
      * @throws \Symfony\Component\HttpKernel\Exception\HttpException
      */
+    #[\Override]
     public function handle(Request $request, Closure $next)
     {
         if (Config::get('laravelcloudflare.replace_ip') === true) {
@@ -38,6 +39,7 @@ class TrustProxies extends Middleware
     /**
      * Sets the trusted proxies on the request.
      */
+    #[\Override]
     protected function setTrustedProxyIpAddresses(Request $request): void
     {
         if ((bool) Config::get('laravelcloudflare.enabled')) {

--- a/src/TrustedProxyServiceProvider.php
+++ b/src/TrustedProxyServiceProvider.php
@@ -4,7 +4,7 @@ namespace Monicahq\Cloudflare;
 
 use Illuminate\Support\ServiceProvider;
 
-class TrustedProxyServiceProvider extends ServiceProvider
+final class TrustedProxyServiceProvider extends ServiceProvider
 {
     /**
      * Bootstrap any package services.


### PR DESCRIPTION
Eliminate compatibility with Laravel 9 and 10, updating dependencies and requirements accordingly. Adjust the PHP version requirement and refine the command descriptions.